### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v1.0.11
+- Set synoinfo.conf support_btrfs_dedupe to no if --restore option used.
+- Skip memory size check if --restore option used.
+
 v1.0.10
 - Fixed bugs where script was getting the wrong amount of memory on some models.
 - Fixed bug in DSM 7.2-64570 due to dmidecode now returning memory size in GB.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Works for DSM from 7.01 and later. As for which models it will work with, I don'
 
 - Deduplication requires 16GB of memory or more.
 - Deduplication only works on SSD volumes that are formatted in Btrfs.
-- The SSD volume needs **usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-us/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
+- The SSD volume needs **usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-us/DSM/help/DSM/StorageManager/volume_view_usage).
 
 Because the bc command is not included in DSM you need to install **SynoCli misc. Tools** from SynoCommunity for this script to work.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Works for DSM from 7.01 and later. As for which models it will work with, I don'
 
 - Deduplication requires 16GB of memory or more.
 - Deduplication only works on SSD volumes that are formatted in Btrfs.
+- The SSD volume needs **usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-us/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
 
 Because the bc command is not included in DSM you need to install **SynoCli misc. Tools** from SynoCommunity for this script to work.
 


### PR DESCRIPTION
v1.0.11
- Set synoinfo.conf support_btrfs_dedupe to no if --restore option used.
- Skip memory size check if --restore option used.
