### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v1.1.12
+v1.1.13
 - Now works for HDDs.
 - Now works for M.2 drives in a PCIe adapter card (E10M20-T1, M2D20, M2D18 or M2D17).
 - Removed the need for bc by using xargs instead.
@@ -6,6 +6,7 @@ v1.1.12
 - Added email option for cleaner emails from task scheduler.
 - Changed to restore synoinfo.conf settings from settings in backup file.
 - Now warns you if script is located on an NVMe drive.
+- Bug fix autoupdate.
 
 v1.0.11
 - Set synoinfo.conf support_btrfs_dedupe to no if --restore option used.

--- a/syno_enable_dedupe.sh
+++ b/syno_enable_dedupe.sh
@@ -9,7 +9,7 @@
 # sudo /volume1/scripts/syno_enable_dedupe.sh
 #-------------------------------------------------------------------------------
 
-scriptver="v1.1.12"
+scriptver="v1.1.13"
 script=Synology_enable_Deduplication
 repo="007revad/Synology_enable_Deduplication"
 
@@ -65,8 +65,8 @@ args=("$@")
 autoupdate=""
 
 # Check for flags with getopt
-if options="$(getopt -o abcdefghijklmnopqrstuvwxyz0123456789 -a \
-    -l skip,check,restore,help,version,email,autoupdate,log,debug -- "$@")"; then
+if options="$(getopt -o abcdefghijklmnopqrstuvwxyz0123456789 -l \
+    skip,check,restore,help,version,email,autoupdate:,log,debug -- "$@")"; then
     eval set -- "$options"
     while true; do
         case "${1,,}" in


### PR DESCRIPTION
v1.1.13
- Now works for HDDs.
- Now works for M.2 drives in a PCIe adapter card (E10M20-T1, M2D20, M2D18 or M2D17).
- Removed the need for bc by using xargs instead.
- Added autoupdate option.
- Added email option for cleaner emails from task scheduler.
- Changed to restore synoinfo.conf settings from settings in backup file.
- Now warns you if script is located on an NVMe drive.
- Bug fix autoupdate.