### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ v1.2.14
 - Added model or DSM version not supported message if required files are missing.
 - Improved restore process.
 - Changes for DSM 7.2.1 only:
+  - Supports V1000, R1000, Geminilake, Broadwellnkv2, Broadwellnk, Broadwell, Purley and Epyc7002.
   - Does not require a reboot.
   - Added message at end to refresh browser.
   - If less than 16GB of memory installed enables tiny deduplication (which only needs 4GB).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+v1.2.14
+- Changed to support DSM 7.2.1 differently than 7.01 to 7.2.
+- Added model or DSM version not supported message if required files are missing.
+- Improved restore process.
+- Changes for DSM 7.2.1 only:
+  - Does not require a reboot.
+  - Added message at end to refresh browser.
+  - If less than 16GB of memory installed enables tiny deduplication (which only needs 4GB).
+  - Added -t, --tiny option to force enabling tiny deduplication.
+
 v1.1.13
 - Now works for HDDs.
 - Now works for M.2 drives in a PCIe adapter card (E10M20-T1, M2D20, M2D18 or M2D17).

--- a/README.md
+++ b/README.md
@@ -15,52 +15,39 @@ Enable data deduplication with non-Synology SSDs and unsupported NAS models
 
 It works on [Synology models that do offically support data deduplication](https://kb.synology.com/en-global/DSM/tutorial/Which_models_support_data_deduplication).
 
-It works on other models with one of following [CPU architectures](https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have): V1000, R1000, Geminilake, Apollolake and some Broadwellnk.
+It works in DSM 7.2.1 on models with one of following [CPU architectures](https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have): V1000, R1000, Geminilake, Broadwellnkv2, Broadwellnk, Broadwell, Purley and Epyc7002.
 
-Purley, Epyc7002, Broadwellnkv2, Broadwellnk and Broadwell.
+It works in DSM 7.0.1 to 7.2 on models with one of following [CPU architectures](https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have): V1000, R1000, Geminilake, Apollolake and some Broadwellnk.
 
 Please [leave a comment in this discussion](https://github.com/007revad/Synology_enable_Deduplication/discussions/31) if it works, or doesn't work, for you.
 
-### Confirmed working on
+### Requirements
+
+- Btrfs Tiny Data Deduplication requires 4GB of memory or more.
+- Btrfs Data Deduplication requires 16GB of memory or more.
+- The volume needs **Usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-global/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
+
+<br>
+
+### Works in DSM 7.2.1 for the following models
 
 | Model      | CPU Arch      | DSM version                       | Works  | Notes |
 |------------|---------------|-----------------------------------|--------|-------|
 | DS224+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS1823xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS923+     | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS923+     | R1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS923+     | R1000         | DSM 7.2-64570                     | yes    | |
 | DS723+     | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS423+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS3622xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS3622xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | |
-| DS3622xs+  | Broadwellnk   | DSM 7.2-64561                     | yes    | |
-| DS3622xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 1          | **No** | |
 | DS2422xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS1821+    | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS1821+    | V1000         | DSM 7.2.1-69057                   | yes    | |
-| DS1821+    | V1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS1821+    | V1000         | DSM 7.2-64570                     | yes    | |
-| DS1821+    | V1000         | DSM 7.2-64561                     | yes    | |
-| DS1821+    | V1000         | DSM 7.1.1-42962 Update 4          | yes    | |
 | DS1621+    | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS1621xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS1621xs+  | Broadwellnk   | DSM 7.2-64570 Update 3            | yes    | |
-| DS1621xs+  | Broadwellnk   | DSM 7.2-64570                     | yes    | |
 | DS1522+    | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS1520+    | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS920+     | Geminilake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS920+     | Geminilake    | DSM 7.2-64570                     | yes    | |
-| DS720+     | Geminilake    | DSM 7.2-64570                     | yes    | |
 | DS420+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS220+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS1019+    | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS1019+    | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS1019+    | Apollolake    | DSM 7.2-64570                     | yes    | |
 | DS3018xs   | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| DS1618+    | Denverton     |                                   | **No** | Denverton not supported |
-| DS918+     | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS918+     | Apollolake    | DSM 7.2-64570                     | yes    | |
 | DS3017xsII | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | DS3017xs   | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | | | | | |
@@ -70,8 +57,6 @@ Please [leave a comment in this discussion](https://github.com/007revad/Synology
 | RS822xs+   | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | RS422xs+   | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | RS4021xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
-| RS4021xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | |
-| RS4021xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 2          | yes    | |
 | RS3621RPxs | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | RS3621xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | RS2821RPxs+ | V1000        | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
@@ -100,11 +85,36 @@ Please [leave a comment in this discussion](https://github.com/007revad/Synology
 | SA3410     | Broadwellnkv2 | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 | SA3400     | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 
-## Requirements
 
-- Btrfs Tiny Data Deduplication requires 4GB of memory or more. DS models 
-- Btrfs Data Deduplication requires 16GB of memory or more.
-- The volume needs **Usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-global/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
+### Confirmed working in older DSM versions
+
+| Model      | CPU Arch      | DSM version                       | Works  | Notes |
+|------------|---------------|-----------------------------------|--------|-------|
+| DS923+     | R1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS923+     | R1000         | DSM 7.2-64570                     | yes    | |
+| DS3622xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | Update to DSM 7.2.1 |
+| DS3622xs+  | Broadwellnk   | DSM 7.2-64561                     | yes    | |
+| DS3622xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 1          | **No** | Update to DSM 7.2.1 |
+| RS4021xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | Update to DSM 7.2.1 |
+| RS4021xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 2          | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64570                     | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64561                     | yes    | |
+| DS1821+    | V1000         | DSM 7.1.1-42962 Update 4          | yes    | |
+| DS1621xs+  | Broadwellnk   | DSM 7.2-64570 Update 3            | yes    | |
+| DS1621xs+  | Broadwellnk   | DSM 7.2-64570                     | yes    | |
+| DS920+     | Geminilake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS920+     | Geminilake    | DSM 7.2-64570                     | yes    | |
+| DS720+     | Geminilake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS720+     | Geminilake    | DSM 7.2-64570                     | yes    | |
+| DS1019+    | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS1019+    | Apollolake    | DSM 7.2-64570                     | yes    | |
+| DS1618+    | Denverton     |                                   | **No** | Denverton not supported |
+| DS918+     | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS918+     | Apollolake    | DSM 7.2-64570                     | yes    | |
+| DS3617xs   | Broadwell     |                                   | **No** | Update to DSM 7.2.1 |
+
+<br>
 
 ## Download the script
 
@@ -152,6 +162,8 @@ After any DSM update you will need to run this script, and the Synology_HDD_db s
 Or you can schedule both Synology_enable_Deduplication and Synology_HDD_db to run when the Synology shuts down, to avoid having to remember to run both scripts after a DSM update.
 
 See <a href=how_to_schedule.md/>How to schedule a script in Synology Task Scheduler</a>
+
+<br>
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -15,48 +15,96 @@ Enable data deduplication with non-Synology SSDs and unsupported NAS models
 
 It works on [Synology models that do offically support data deduplication](https://kb.synology.com/en-global/DSM/tutorial/Which_models_support_data_deduplication).
 
-It works on other models with one of following [CPU architectures](https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have): R1000, Geminilake, V1000, Apollolake and some Broadwellnk.
+It works on other models with one of following [CPU architectures](https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have): V1000, R1000, Geminilake, Apollolake and some Broadwellnk.
 
-It may work for other Synology NAS models.
+Purley, Epyc7002, Broadwellnkv2, Broadwellnk and Broadwell.
 
 Please [leave a comment in this discussion](https://github.com/007revad/Synology_enable_Deduplication/discussions/31) if it works, or doesn't work, for you.
 
 ### Confirmed working on
 
-| Model      | CPU Arch    | DSM version                       | Works  | Notes |
-|------------|-------------|-----------------------------------|--------|-------|
-| DS923+     | R1000       | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS923+     | R1000       | DSM 7.2-64570                     | yes    | |
-| DS3622xs+  | Broadwellnk | DSM 7.2-64570                     | **No** | |
-| DS3622xs+  | Broadwellnk | DSM 7.2-64561                     | yes    | |
-| DS3622xs+  | Broadwellnk | DSM 7.1.1-42962 Update 1          | **No** | |
-| RS4021xs+  | Broadwellnk | DSM 7.2-64570                     | **No** | |
-| RS4021xs+  | Broadwellnk | DSM 7.1.1-42962 Update 2          | yes    | |
-| DS1821+    | V1000       | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | |
-| DS1821+    | V1000       | DSM 7.2.1-69057                   | yes    | |
-| DS1821+    | V1000       | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS1821+    | V1000       | DSM 7.2-64570                     | yes    | |
-| DS1821+    | V1000       | DSM 7.2-64561                     | yes    | |
-| DS1821+    | V1000       | DSM 7.1.1-42962 Update 4          | yes    | |
-| DS1621xs+  | Broadwellnk | DSM 7.2-64570 Update 3            | yes    | |
-| DS1621xs+  | Broadwellnk | DSM 7.2-64570                     | yes    | |
-| DS920+     | Geminilake  | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS920+     | Geminilake  | DSM 7.2-64570                     | yes    | |
-| DS720+     | Geminilake  | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS720+     | Geminilake  | DSM 7.2-64570                     | yes    | |
-| DS1019+    | Apollolake  | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS1019+    | Apollolake  | DSM 7.2-64570                     | yes    | |
-| DS1618+    | Denverton   |                                   | **No** | Denverton not supported |
-| DS918+     | Apollolake  | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
-| DS918+     | Apollolake  | DSM 7.2-64570                     | yes    | |
-| DS3617xs   | Broadwell   |                                   | **No** | Broadwell not supported |
+| Model      | CPU Arch      | DSM version                       | Works  | Notes |
+|------------|---------------|-----------------------------------|--------|-------|
+| DS224+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1823xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS923+     | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS923+     | R1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS923+     | R1000         | DSM 7.2-64570                     | yes    | |
+| DS723+     | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS423+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS3622xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS3622xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | |
+| DS3622xs+  | Broadwellnk   | DSM 7.2-64561                     | yes    | |
+| DS3622xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 1          | **No** | |
+| DS2422xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1821+    | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1821+    | V1000         | DSM 7.2.1-69057                   | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64570                     | yes    | |
+| DS1821+    | V1000         | DSM 7.2-64561                     | yes    | |
+| DS1821+    | V1000         | DSM 7.1.1-42962 Update 4          | yes    | |
+| DS1621+    | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1621xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1621xs+  | Broadwellnk   | DSM 7.2-64570 Update 3            | yes    | |
+| DS1621xs+  | Broadwellnk   | DSM 7.2-64570                     | yes    | |
+| DS1522+    | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1520+    | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS920+     | Geminilake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS920+     | Geminilake    | DSM 7.2-64570                     | yes    | |
+| DS720+     | Geminilake    | DSM 7.2-64570                     | yes    | |
+| DS420+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS220+     | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1019+    | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS1019+    | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS1019+    | Apollolake    | DSM 7.2-64570                     | yes    | |
+| DS3018xs   | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS1618+    | Denverton     |                                   | **No** | Denverton not supported |
+| DS918+     | Apollolake    | DSM 7.2-64570 Update 1, 2 and 3   | yes    | |
+| DS918+     | Apollolake    | DSM 7.2-64570                     | yes    | |
+| DS3017xsII | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| DS3017xs   | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| | | | | |
+| DVA1622    | Geminilake    | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| | | | | |
+| RS2423xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS822xs+   | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS422xs+   | R1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS4021xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS4021xs+  | Broadwellnk   | DSM 7.2-64570                     | **No** | |
+| RS4021xs+  | Broadwellnk   | DSM 7.1.1-42962 Update 2          | yes    | |
+| RS3621RPxs | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS3621xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS2821RPxs+ | V1000        | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS2421xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS1221xs+  | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS1619xs+  | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS3618xs   | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS3617xs+  | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS3617RPxs | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS18017xs+ | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| RS4017xs+  | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| | | | | |
+| FS6400     | Purley        | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS3600     | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS3410     | Broadwellnkv2 | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS3400     | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS2500     | V1000         | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS2017     | Broadwell     | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| FS1018     | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| | | | | |
+| HD6500     | Purley        | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| | | | | |
+| SA6400     | Epyc7002      | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| SA3610     | Broadwellnkv2 | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| SA3600     | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| SA3410     | Broadwellnkv2 | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
+| SA3400     | Broadwellnk   | DSM 7.2.1-69057 Update 1, 2 and 3 | yes    | Use v1.2.14 or later |
 
 ## Requirements
 
-- Deduplication requires 16GB of memory or more.
-- Deduplication only works on SSD volumes that are formatted in Btrfs.
-- The SSD volume needs **usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-global/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
-- SSD drive(s) in drive bays or internal M.2 slot(s).
+- Btrfs Tiny Data Deduplication requires 4GB of memory or more. DS models 
+- Btrfs Data Deduplication requires 16GB of memory or more.
+- The volume needs **Usage detail analysis** enabled. See [Enable and View Usage Details](https://kb.synology.com/en-global/DSM/help/DSM/StorageManager/volume_view_usage?version=7).
 
 ## Download the script
 

--- a/syno_enable_dedupe.sh
+++ b/syno_enable_dedupe.sh
@@ -445,9 +445,8 @@ rebootmsg(){
 reloadmsg(){ 
     # Reload browser prompt
     echo -e "\nFinished"
-    echo -e "\nIf you have Storage Manager open already you need to:"
-    echo "   1. Close Storage Manager."
-    echo "   2. Refresh the browser window or tab."
+    echo -e "\nIf you have DSM open in a browser you need to"
+    echo "refresh the browser window or tab."
     exit
 }
 
@@ -499,7 +498,7 @@ if [[ $restore == "yes" ]]; then
             string1="(SYNO.SDS.StorageUtils.supportBtrfsDedupe)"
             string2="(SYNO.SDS.StorageUtils.supportBtrfsDedupe&&e.dedup_info.show_config_btn)"
 
-            if grep -o "string1" "${strgmgr}" >/dev/null; then
+            if grep -o "$string1" "${strgmgr}" >/dev/null; then
                 # Restore string in file
                 sed -i "s/${string1}/${string2/&&/\\&\\&}/g" "$strgmgr"
 


### PR DESCRIPTION
v1.2.14
- Changed to support DSM 7.2.1 differently than 7.01 to 7.2.
- Added model or DSM version not supported message if required files are missing.
- Improved restore process.
- Changes for DSM 7.2.1 only:
  - Supports V1000, R1000, Geminilake, Broadwellnkv2, Broadwellnk, Broadwell, Purley and Epyc7002.
  - Does not require a reboot.
  - Added message at end to refresh browser.
  - If less than 16GB of memory installed enables tiny deduplication (which only needs 4GB).
  - Added -t, --tiny option to force enabling tiny deduplication.
